### PR TITLE
Simplified style sheets

### DIFF
--- a/src/demo/java/RtfTOCDemo.java
+++ b/src/demo/java/RtfTOCDemo.java
@@ -1,0 +1,50 @@
+//import static com.tutego.jrtf.Rtf.document;
+//import static com.tutego.jrtf.RtfDocfmt.*;
+//import static com.tutego.jrtf.RtfHeader.*;
+//import static com.tutego.jrtf.RtfInfo.*;
+//import static com.tutego.jrtf.RtfFields.*;
+//import static com.tutego.jrtf.RtfPara.*;
+//import static com.tutego.jrtf.RtfSectionFormatAndHeaderFooter.*;
+//import static com.tutego.jrtf.RtfText.*;
+//import static com.tutego.jrtf.RtfUnit.*;
+import static com.tutego.jrtf.Rtf.rtf;
+import static com.tutego.jrtf.RtfFields.tableOfContentsField;
+import static com.tutego.jrtf.RtfPara.*;
+import java.awt.Desktop;
+import java.io.*;
+import com.tutego.jrtf.*;
+//import com.tutego.jrtf.RtfPicture.PictureType;
+
+/**
+ * Example class.
+ */
+public class RtfTOCDemo
+{
+  /**
+   * Start application.
+   * @param args Program arguments.
+   * @throws IOException If something goes wrong during writing.
+   */
+  public static void main( String... args ) throws IOException
+  {
+    File out = new File( "out-toc.rtf" );
+
+    rtf()
+    	.headerStyles(RtfHeaderStyle.values())
+    	.section(p("Table of content\n"),p(tableOfContentsField()))
+    	.section(
+    			p(RtfHeaderStyle.HEADER_1, "Style - Header 1"),
+    			p(RtfHeaderStyle.HEADER_2, "Style - Header 2"),
+    			p(RtfHeaderStyle.HEADER_3, "Style - Header 3"),
+    			p(RtfHeaderStyle.HEADER_1, "Style - Header 1"),
+    			p(RtfHeaderStyle.HEADER_2, "Style - Header 2")
+    	)
+    	.out( new FileWriter( out ) );
+
+    try
+    {
+      Desktop.getDesktop().open( out );
+    }
+    catch ( IOException e ) { e.printStackTrace(); }
+  }
+}

--- a/src/main/java/com/tutego/jrtf/Rtf.java
+++ b/src/main/java/com/tutego/jrtf/Rtf.java
@@ -54,8 +54,8 @@ public class Rtf
   /** List of fonts. */
   private List<RtfHeaderFont> headerFonts = new ArrayList<RtfHeaderFont>();
 
-//  /** List of style sheets. */
-//  private List<RtfHeaderStyle> headerStyles = new ArrayList<RtfHeaderStyle>();
+  /** List of style sheets. */
+  private List<RtfHeaderStyle> headerStyles = new ArrayList<RtfHeaderStyle>();
 
   /** Document info. */
   private StringBuilder info = new StringBuilder();
@@ -157,7 +157,21 @@ public class Rtf
 
     return this;
   }
-
+  
+  /**
+   * Writes stylesheet group, which contains information about styles used in the document.
+   * 
+   * @param styles RTF style sheet objects.
+   * @return {@code this}-reference.
+   */
+  public Rtf headerStyles(RtfHeaderStyle... styles) {
+	for (RtfHeaderStyle rtfStyle : styles)
+  	  if (!headerStyles.contains(rtfStyle)) {
+		headerStyles.add(rtfStyle);
+	  }
+  	return this;
+  }
+	
   /**
    * Writes information group, which contains information about the document.
    * This can include the title, author, keywords, comments, and other information
@@ -241,6 +255,18 @@ public class Rtf
   public Rtf p( Object... texts )
   {
     return section( RtfPara.p( texts ) );
+  }
+  
+  /**
+   * Appends a sequence of text in a new paragraph to the RTF document.
+   * A convenience method which is equals to {@code section(RtfPara.p( style, texts));}.
+   * @param style Style sheet to set in paragraph.
+   * @param texts Text to put in paragraph.
+   * @return {@code this}-reference.
+   */
+  public Rtf p( RtfHeaderStyle style,  Object... texts )
+  {
+    return section( RtfPara.p( style, texts ) );
   }
 
   /**
@@ -376,15 +402,15 @@ public class Rtf
      * <stylesheet> := '{' \ stylesheet <style>+ '}'
      */
   
-//    if ( ! headerStyles.isEmpty() )
-//    {
-//      out.append( "\n{\\stylesheet" );
-//      for ( RtfHeaderStyle style : headerStyles )
-//        style.writeStyle( out );
-//      
-//      out.append( '}' );
-//    }
-//    
+    if ( ! headerStyles.isEmpty() )
+    {
+      out.append( "\n{\\stylesheet" );
+      for ( RtfHeaderStyle style : headerStyles )
+    	out.append(style.toString());
+      
+      out.append( '}' );
+    }
+    
     out.append( '\n' );
     
     // Write <info> 

--- a/src/main/java/com/tutego/jrtf/RtfHeaderStyle.java
+++ b/src/main/java/com/tutego/jrtf/RtfHeaderStyle.java
@@ -1,0 +1,104 @@
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'jRTF' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.tutego.jrtf;
+
+/**
+ * Represents a style sheet definition for the RTF header.
+ */
+public enum RtfHeaderStyle {
+
+	/** Default style */
+	NORMAL(0) {
+		@Override
+		public String toString() {
+			return "{\\s0 Normal;}";
+		}
+	},
+
+	/** Header 1 Style */
+	HEADER_1(1) {
+		@Override
+		public String toString() {
+			return "{\\s1 Heading 1;}";
+		}
+	},
+
+	/** Header 2 Style */
+	HEADER_2(2) {
+		@Override
+		public String toString() {
+			return "{\\s2 Heading 2;}";
+		}
+	},
+
+	/** Header 3 Style */
+	HEADER_3(3) {
+		@Override
+		public String toString() {
+			return "{\\s3 Heading 3;}";
+		}
+	},
+
+	/** Header 4 Style */
+	HEADER_4(4) {
+		@Override
+		public String toString() {
+			return "{\\s4 Heading 4;}";
+		}
+	},
+
+	/** Header 5 Style */
+	HEADER_5(5) {
+		@Override
+		public String toString() {
+			return "{\\s5 Heading 5;}";
+		}
+	};
+	
+	/**
+	 * Constructor.
+	 * @param id document style sheet id
+	 */
+	RtfHeaderStyle(int id) {
+		this.id = id;
+	}
+	
+	/**
+	 * Style sheet id.
+	 */
+	private int id;
+	
+	/**
+	 * Returns document style sheet id.
+	 * @return id
+	 */
+	public int getId() {
+		return id;
+	}	
+}

--- a/src/main/java/com/tutego/jrtf/RtfPara.java
+++ b/src/main/java/com/tutego/jrtf/RtfPara.java
@@ -75,6 +75,18 @@ public abstract class RtfPara
   {
     return p( RtfText.text( texts ) );
   }
+  
+  /**
+   * Builds a paragraph of objects (with will be converted to Strings) and RtfText.
+   * Convenience method for {@code p(RtfText.text(texts))}.
+   * @param style Style sheet to set in paragraph.
+   * @param texts Text to set in paragraph.
+   * @return New {@code RtfTextPara} object with text.
+   */
+  public static RtfTextPara p(RtfHeaderStyle style, Object... texts )
+  {
+    return p(style, RtfText.text( texts ) );
+  }
 
   /**
    * A paragraph with a collection of text. This paragraph will inherit all
@@ -86,25 +98,42 @@ public abstract class RtfPara
    */
   public static RtfTextPara p( final RtfText... texts )
   {
-    if ( texts == null || texts.length == 0 )
-      return new RtfTextPara() {
-      @Override void rtf( Appendable out, boolean withEndingPar ) throws IOException {
-        out.append( "\\par" );
-      }
-    };
-    
-    return new RtfTextPara() {
-      @Override void rtf( Appendable out, boolean withEndingPar ) throws IOException {
-        out.append( "{" ); // \\pard
-        out.append( textparFormatRtf() );
-        for ( RtfText rtfText : texts )
-          rtfText.rtf( out );
-        if ( withEndingPar )     // if its in table, withEndingPar will be false
-          out.append( "\\par" );
-        out.append( "}\n" );
-      }
-    };
+	  return p( null , texts );
   }
+
+  /**
+   * A paragraph with a collection of text. This paragraph will inherit all
+   * the settings from the other paragraph. Look for {@link #pard(RtfText...)} if you
+   * look for a method where paragraph attributes are not inherited to the next
+   * paragraph.
+   * @param style Style sheet to set in paragraph.
+   * @param texts Text to set in paragraph.
+   * @return New {@code RtfTextPara} object with text.
+   */
+  public static RtfTextPara p( final RtfHeaderStyle style , final RtfText... texts )
+  {
+	    if ( texts == null || texts.length == 0 )
+	      return new RtfTextPara() {
+	      @Override void rtf( Appendable out, boolean withEndingPar ) throws IOException {
+	        out.append( "\\par" );
+	      }
+	    };
+	    
+	    return new RtfTextPara() {
+	      @Override void rtf( Appendable out, boolean withEndingPar ) throws IOException {
+	        out.append( "{" ); // \\pard
+	        if(style != null) {
+	        	out.append( "\\s" + style.getId());
+	        }
+	        out.append( textparFormatRtf() );
+	        for ( RtfText rtfText : texts )
+	          rtfText.rtf( out );
+	        if ( withEndingPar )     // if its in table, withEndingPar will be false
+	          out.append( "\\par" );
+	        out.append( "}\n" );
+	      }
+	    };
+	  }
 
   /**
    * A paragraph with a collection of text. This paragraph will not inherit the
@@ -116,6 +145,20 @@ public abstract class RtfPara
    */
   public static RtfTextPara pard( final RtfText... texts )
   {
+	  return pard( null , texts );
+  }
+
+  /**
+   * A paragraph with a collection of text. This paragraph will not inherit the
+   * settings from the other paragraph. Look for {@link #p(RtfText...)} if you
+   * look for a method where paragraph attributes are inherited to the next
+   * paragraph.
+   * @param style Style sheet to set in paragraph.
+   * @param texts Text to set in paragraph.
+   * @return New {@code RtfTextPara} object with text.
+   */
+  public static RtfTextPara pard( final RtfHeaderStyle style, final RtfText... texts )
+  {
     if ( texts == null || texts.length == 0 )
       return new RtfTextPara() {
       	@Override void rtf( Appendable out, boolean withEndingPar ) throws IOException {
@@ -126,6 +169,9 @@ public abstract class RtfPara
     return new RtfTextPara() {
       @Override void rtf( Appendable out, boolean withEndingPar ) throws IOException {
         out.append( "{\\pard" );
+        if(style != null) {
+        	out.append( "\\s" + style.getId());
+        }
         out.append( textparFormatRtf() );
         for ( RtfText rtfText : texts )
           rtfText.rtf( out );


### PR DESCRIPTION
Added simplified style sheets (RtfHeaderStyle). Now it's possible to use
predefined style on paragraph. Functionality added mostly for table of
content. "\tc" command don't work as it should in Office 2010, UTF signs
aren't displayed properly. Using Word style "Header 1" allow building
table of content without "\tc" command. Added table of content example.